### PR TITLE
Remove s3.requireLoginToView, deprecated

### DIFF
--- a/census-app/config.toml
+++ b/census-app/config.toml
@@ -111,10 +111,6 @@ serverPort = 80
 # Default: (unset)
 #secretAccessKey =
 
-# Make the shared app visible only to users who have been granted view permission. If you are interested in this option, contact us at support@streamlit.io.
-# Default: false
-requireLoginToView = false
-
 # The "subdirectory" within the S3 bucket where to save apps.
 # S3 calls paths "keys" which is why the keyPrefix is like a subdirectory. Use "" to mean the root directory.
 # Default: ""


### PR DESCRIPTION
I was not able to successfully deploy the app using this config. Seems like requireLoginToView is deprecated - see: https://github.com/streamlit/streamlit/issues/886.

Thanks for your tutorial btw - really appreciated it!